### PR TITLE
Add tag context menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ This project shows a simple page with a left menu and a tag bar that tracks
 visited menu items. Selecting a menu link adds a tag to the bar. Clicking a tag
 or its close icon allows switching between or removing visited pages.
 
+Right-click any tag to change its font color, background color, or to close all
+tags at once.
+
 ## How to open
 
 No build step is required. Simply open `index.html` in a web browser or serve

--- a/index.html
+++ b/index.html
@@ -64,13 +64,30 @@
 .tags-view-item.pinned .pin {
   color: #ff9900;
 }
-.tags-view-placeholder {
-  border: 1px dashed #d8dce5;
-  background: #f0f0f0;
-  border-radius: 3px;
-  margin-right: 5px;
-  visibility: visible !important;
-}
+  .tags-view-placeholder {
+    border: 1px dashed #d8dce5;
+    background: #f0f0f0;
+    border-radius: 3px;
+    margin-right: 5px;
+    visibility: visible !important;
+  }
+  .context-menu {
+    position: absolute;
+    background: #fff;
+    border: 1px solid #ccc;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    z-index: 1000;
+  }
+  .context-menu li {
+    padding: 4px 8px;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+  .context-menu li:hover {
+    background: #eee;
+  }
 </style>
 </head>
 <body>

--- a/tagsView.js
+++ b/tagsView.js
@@ -1,6 +1,13 @@
 $(function () {
   var visited = [];
 
+  var $contextMenu = $('<ul class="context-menu">\n' +
+    '  <li data-action="font">Font Color</li>\n' +
+    '  <li data-action="background">Background Color</li>\n' +
+    '  <li data-action="close-all">Close All</li>\n' +
+    '</ul>').appendTo('body').hide();
+  var $menuTarget = null;
+
   function refreshVisited() {
     visited = $('.tags-view-item').map(function () {
       return { path: $(this).data('path'), title: $(this).data('title') };
@@ -45,6 +52,11 @@ $(function () {
       visited = visited.filter(v => v.path !== path);
       $tag.remove();
     })
+    .on('contextmenu', '.tags-view-item', function (e) {
+      e.preventDefault();
+      $menuTarget = $(this);
+      $contextMenu.css({ top: e.pageY, left: e.pageX }).show();
+    })
     .on('click', '.tags-view-item', function () {
       var path  = $(this).data('path');
       var title = $(this).data('title');
@@ -60,4 +72,27 @@ $(function () {
     $('.tags-view-item').removeClass('active');
     $('.tags-view-item[data-path="'+path+'"]').addClass('active');
   }
+
+  $(document).on('click', function () {
+    $contextMenu.hide();
+  });
+
+  $contextMenu.on('click', 'li', function () {
+    var action = $(this).data('action');
+    if (action === 'font') {
+      var color = prompt('Font color (#rrggbb or name)');
+      if (color) {
+        ($menuTarget || $('.tags-view-item')).css('color', color);
+      }
+    } else if (action === 'background') {
+      var color = prompt('Background color (#rrggbb or name)');
+      if (color) {
+        ($menuTarget || $('.tags-view-item')).css('background', color);
+      }
+    } else if (action === 'close-all') {
+      visited = [];
+      $('.tags-view-wrapper').empty();
+    }
+    $contextMenu.hide();
+  });
 });


### PR DESCRIPTION
## Summary
- add a context menu for tags with font color, background color and close-all options
- style context menu in `index.html`
- update README to document the right-click feature

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853fef0cf948331ae64da1a572e29fd