### PR TITLE
Add scroll controls to tag list

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ or its close icon allows switching between or removing visited pages.
 Right-click any tag to change its font color, background color, or to close all
 tags at once.
 
+When the tag bar overflows horizontally, use the arrow buttons on the sides to
+scroll left or right.
+
 ## How to open
 
 No build step is required. Simply open `index.html` in a web browser or serve

--- a/index.html
+++ b/index.html
@@ -28,14 +28,34 @@
     flex-grow: 1;
     padding: 16px;
   }
-  .tags-view-wrapper {
+  .tags-view-container {
+    position: relative;
     margin-bottom: 12px;
     height: 32px;
     background: #eee;
+  }
+  .tags-view-wrapper {
+    height: 32px;
+    white-space: nowrap;
+    overflow-x: auto;
     display: flex;
     align-items: center;
     padding-left: 8px;
   }
+  .scroll-left,
+  .scroll-right {
+    position: absolute;
+    top: 0;
+    width: 24px;
+    height: 32px;
+    line-height: 32px;
+    text-align: center;
+    cursor: pointer;
+    user-select: none;
+    background: rgba(0, 0, 0, 0.1);
+  }
+  .scroll-left { left: 0; }
+  .scroll-right { right: 0; }
   .tags-view-item {
     display: inline-block;
     position: relative;
@@ -119,7 +139,11 @@
   </div>
 
   <div class="main-content">
-    <div class="tags-view-wrapper"></div>
+    <div class="tags-view-container">
+      <span class="scroll-left">&#9664;</span>
+      <div class="tags-view-wrapper"></div>
+      <span class="scroll-right">&#9654;</span>
+    </div>
     <p id="hint">Select a menu item.</p>
   </div>
 </div>

--- a/tagsView.js
+++ b/tagsView.js
@@ -1,5 +1,6 @@
 $(function () {
   var visited = [];
+  var $wrapper = $('.tags-view-wrapper');
 
   var $contextMenu = $('<ul class="context-menu">\n' +
     '  <li data-action="font">Font Color</li>\n' +
@@ -15,7 +16,7 @@ $(function () {
   }
 
   $.getScript('https://ajax.googleapis.com/ajax/libs/jqueryui/1.13.2/jquery-ui.min.js', function () {
-    $('.tags-view-wrapper').sortable({
+    $wrapper.sortable({
       items: '.tags-view-item',
       tolerance: 'pointer',
       placeholder: 'tags-view-placeholder',
@@ -35,7 +36,7 @@ $(function () {
 
     if (!visited.some(v => v.path === path)) {
       visited.push({ path, title });
-      $('.tags-view-wrapper').append(
+      $wrapper.append(
         '<span class="tags-view-item" data-path="'+path+'" data-title="'+title+'">'+
           title+' <span class="close">×</span></span>'
       );
@@ -91,8 +92,27 @@ $(function () {
       }
     } else if (action === 'close-all') {
       visited = [];
-      $('.tags-view-wrapper').empty();
+      $wrapper.empty();
     }
     $contextMenu.hide();
   });
+
+  function updateButtons() {
+    var scrollLeft = $wrapper.scrollLeft();
+    var maxScroll = $wrapper[0].scrollWidth - $wrapper.innerWidth();
+    $('.scroll-left').toggle(scrollLeft > 0);
+    $('.scroll-right').toggle(scrollLeft < maxScroll);
+  }
+
+  $('.scroll-left').on('click', function () {
+    $wrapper.animate({ scrollLeft: '-=100' }, 200, updateButtons);
+  });
+
+  $('.scroll-right').on('click', function () {
+    $wrapper.animate({ scrollLeft: '+=100' }, 200, updateButtons);
+  });
+
+  $wrapper.on('scroll', updateButtons);
+
+  updateButtons();
 });


### PR DESCRIPTION
## Summary
- wrap tag list in a new container with scroll buttons
- style the wrapper and buttons
- add scrolling logic to the script
- document the new arrows in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68560a8c76e08331909f87f0d33d7a3c