### PR TITLE
Add scrollable tags view with arrow buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,11 @@
   </div>
 
   <div class="main-content">
-    <div class="tags-view-wrapper"></div>
+    <div class="tags-view-container">
+      <button class="scroll-btn left">&#8249;</button>
+      <div class="tags-view-wrapper"></div>
+      <button class="scroll-btn right">&#8250;</button>
+    </div>
     <p id="hint">Select a menu item.</p>
   </div>
 </div>

--- a/style.css
+++ b/style.css
@@ -22,13 +22,30 @@ body { font-family: Arial, sans-serif; margin: 0; }
   flex-grow: 1;
   padding: 16px;
 }
-.tags-view-wrapper {
+.tags-view-container {
   margin-bottom: 12px;
   height: 32px;
   background: #eee;
   display: flex;
   align-items: center;
+}
+
+.tags-view-wrapper {
+  flex: 1;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  overflow-x: auto;
+  white-space: nowrap;
   padding-left: 8px;
+}
+
+.scroll-btn {
+  width: 24px;
+  height: 32px;
+  background: #ddd;
+  border: none;
+  cursor: pointer;
 }
 .tags-view-item {
   display: inline-block;

--- a/tagsView.js
+++ b/tagsView.js
@@ -79,6 +79,16 @@ $(function () {
     $contextMenu.hide();
   });
 
+  $('.scroll-btn.left').on('click', function () {
+    var $wrap = $('.tags-view-wrapper');
+    $wrap.animate({ scrollLeft: $wrap.scrollLeft() - 120 }, 200);
+  });
+
+  $('.scroll-btn.right').on('click', function () {
+    var $wrap = $('.tags-view-wrapper');
+    $wrap.animate({ scrollLeft: $wrap.scrollLeft() + 120 }, 200);
+  });
+
   $contextMenu.on('click', 'li', function () {
     var action = $(this).data('action');
     if (action === 'font') {


### PR DESCRIPTION
## Summary
- add left/right navigation arrows to switch between tags
- style new arrow controls and adjust tag wrapper
- support horizontal scrolling via new arrow buttons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856cdd8dafc8331a5317edb7b50c461