### PR TITLE
Fix tag container overflow handling

### DIFF
--- a/style.css
+++ b/style.css
@@ -29,6 +29,8 @@ body { font-family: Arial, sans-serif; margin: 0; }
   left: 204px;
   right: 0;
   z-index: 1;
+  overflow-x: auto;
+  overflow-y: hidden;
 }
 .tags-view-wrapper {
   margin-bottom: 12px;
@@ -37,6 +39,8 @@ body { font-family: Arial, sans-serif; margin: 0; }
   display: flex;
   align-items: center;
   padding-left: 8px;
+  flex-wrap: nowrap;
+  width: max-content;
 }
 .tags-view-item {
   display: inline-block;
@@ -51,6 +55,7 @@ body { font-family: Arial, sans-serif; margin: 0; }
   color: #495060;
   margin-right: 5px;
   border-radius: 3px;
+  flex-shrink: 0;
 }
 .tags-view-item.active {
   background: #42b983;


### PR DESCRIPTION
## Summary
- keep `tags-view-container` width fixed and scrollable when tags exceed available space
- prevent tag items from shrinking

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856faced334833197c84631011d0368