### PR TITLE
Add arrow buttons for tags view scrolling

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,11 @@
 
     <div class="main-content">
       <div class="tags-view-container">
-        <div class="tags-view-wrapper"></div>
+        <span class="scroll-button left">&#9664;</span>
+        <div class="tags-view-scroll">
+          <div class="tags-view-wrapper"></div>
+        </div>
+        <span class="scroll-button right">&#9654;</span>
       </div>
       <p id="hint">Select a menu item.</p>
     </div>

--- a/style.css
+++ b/style.css
@@ -29,8 +29,18 @@ body { font-family: Arial, sans-serif; margin: 0; }
   left: 204px;
   right: 0;
   z-index: 1;
+  display: flex;
+  align-items: center;
+}
+.tags-view-scroll {
   overflow-x: auto;
   overflow-y: hidden;
+  flex: 1;
+}
+.scroll-button {
+  cursor: pointer;
+  padding: 0 8px;
+  user-select: none;
 }
 .tags-view-wrapper {
   margin-bottom: 12px;

--- a/style.css
+++ b/style.css
@@ -33,7 +33,7 @@ body { font-family: Arial, sans-serif; margin: 0; }
   align-items: center;
 }
 .tags-view-scroll {
-  overflow-x: auto;
+  overflow-x: hidden;
   overflow-y: hidden;
   flex: 1;
 }

--- a/tagsView.js
+++ b/tagsView.js
@@ -27,6 +27,16 @@ $(function () {
     console.error('jQuery UI not loaded. Sortable disabled.');
   }
 
+  $('.scroll-button.left').on('click', function () {
+    var $scroll = $('.tags-view-scroll');
+    $scroll.animate({ scrollLeft: '-=100' }, 100);
+  });
+
+  $('.scroll-button.right').on('click', function () {
+    var $scroll = $('.tags-view-scroll');
+    $scroll.animate({ scrollLeft: '+=100' }, 100);
+  });
+
   $('.menu-item').on('click', function (e) {
     e.preventDefault();
     var path  = $(this).attr('href');


### PR DESCRIPTION
## Summary
- add left/right scroll buttons next to the tag bar
- style scroll buttons and move overflow to a new container
- hook buttons up in JS to scroll horizontally

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857081216948331b4ec8f9abd34d15e